### PR TITLE
Impulse response oneof

### DIFF
--- a/src/lib/messages/netsim.proto
+++ b/src/lib/messages/netsim.proto
@@ -7,8 +7,16 @@ package netsim.protobuf;
 
 message ImpulseResponse
 {
-    required string source = 1;
-    required string receiver = 2;
+   oneof src
+   {
+    string source = 1;
+    int32  source_id = 21;
+    }
+    oneof rcv
+    {
+    string receiver = 2;
+    int32  reciver_id = 22;
+    }
     optional int32 number_array_elements = 3 [default = 1];
     repeated RayTrace raytrace = 4;
     message RayTrace
@@ -44,8 +52,16 @@ message ImpulseResponse
 
 message ImpulseRequest
 {
-    required string source = 1;
-    required string receiver = 2;
+   oneof src
+   {
+    string source = 1;
+    int32  source_id = 21;
+    }
+    oneof rcv
+    {
+    string receiver = 2;
+    int32  reciver_id =22;
+    }
 
     optional double sampling_frequency = 6 [default = 12000];
     optional int32 nfft = 7 [default = 2048];

--- a/src/lib/messages/netsim.proto
+++ b/src/lib/messages/netsim.proto
@@ -15,7 +15,7 @@ message ImpulseResponse
     oneof rcv
     {
     string receiver = 2;
-    int32  reciver_id = 22;
+    int32  receiver_id = 22;
     }
     optional int32 number_array_elements = 3 [default = 1];
     repeated RayTrace raytrace = 4;
@@ -60,7 +60,7 @@ message ImpulseRequest
     oneof rcv
     {
     string receiver = 2;
-    int32  reciver_id =22;
+    int32  receiver_id =22;
     }
 
     optional double sampling_frequency = 6 [default = 12000];


### PR DESCRIPTION
Added optional source/receiver specifications in nets.proto: ImpulseRequest/Response using 'oneof'. Should have no effect on the functionality in lames where node names are used, but node names are not inherently included in iris, so VOAT impulse response requests will be done using modem_ids"

see also lamss-shared and mission-lames which have corresponding branches